### PR TITLE
Fix ESM5/FESM5 build: spaces in the absolute path

### DIFF
--- a/build.js
+++ b/build.js
@@ -62,7 +62,7 @@ if (shell.exec(`rollup -c rollup.es.config.js -i ${NPM_DIR}/${PACKAGE}.js -o ${F
 }
 
 shell.echo(`Produce ESM5/FESM5 versions`);
-shell.exec(`ngc -p ${OUT_DIR}/tsconfig-build.json --target es5 -d false --outDir ${OUT_DIR_ESM5_ABS} --sourceMap`);
+shell.exec(`ngc -p ${OUT_DIR}/tsconfig-build.json --target es5 -d false --outDir "${OUT_DIR_ESM5_ABS}" --sourceMap`);
 shell.cp(`-Rf`, [`${OUT_DIR_ESM5}/src/`, `${OUT_DIR_ESM5}/*.js`, `${OUT_DIR_ESM5}/*.js.map`], `${ESM5_DIR}`);
 if (shell.exec(`rollup -c rollup.es.config.js -i ${OUT_DIR_ESM5}/${PACKAGE}.js -o ${FESM5_DIR}/${PACKAGE}.js`).code !== 0) {
     shell.echo(chalk.red(`Error: FESM5 version failed`));


### PR DESCRIPTION
If there are spaces in the absolute path of the library, the build will fail. In my case I replaced "dev" with "dev with spaces" and got following:

> Produce ESM5/FESM5 versions
> cp: no such file or directory: dist/package/esm5/src/
> cp: no such file or directory: dist/package/esm5/*.js
> cp: no such file or directory: dist/package/esm5/*.js.map
> 
> dist/package/esm5/ngx-ui-scroll.js → dist/fesm5/ngx-ui-scroll.js...
> [!] Error: Could not resolve entry module (dist/package/esm5/ngx-ui-scroll.js).
> Error: Could not resolve entry module (dist/package/esm5/ngx-ui-scroll.js).
>     at error (/Users/dhilt/dev x/ngx-ui-scroll/node_modules/rollup/dist/shared/rollup.js:5211:30)
>     at ModuleLoader.loadEntryModule (/Users/dhilt/dev with spaces/ngx-ui-scroll/node_modules/rollup/dist/shared/rollup.js:18275:16)
>     at async Promise.all (index 0)
> 
> Error: FESM5 version failed
> 

This PR fixes the issue. Initially it had been discovered [here](https://github.com/dhilt/ngx-ui-scroll/pull/223), but I improved the suggested solution. 